### PR TITLE
fix: remove duplicate employee filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,13 +138,6 @@
           <label>Maand
             <input type="month" id="filterMaand" />
           </label>
-	<label id="filterMedewerkerWrap" class="small hidden">
-      Medewerker
-      <select id="filterMedewerker">
-    <option value="">Alle</option>
-  </select>
-</label>
-
 
           <!-- Admin-overzicht -->
           <label class="small">
@@ -152,11 +145,11 @@
             Admin-overzicht (alle medewerkers)
           </label>
 
-          <!-- NIEUW: Admin-filter op medewerker -->
-          <label>Medewerker
+          <!-- Admin-filter op medewerker -->
+          <label id="filterMedewerkerWrap" class="small hidden">
+            Medewerker
             <select id="filterMedewerker">
-              <option value="">Alle medewerkers</option>
-              <!-- wordt automatisch gevuld door app.js -->
+              <option value="">Alle</option>
             </select>
           </label>
         </div>


### PR DESCRIPTION
## Summary
- remove duplicate "Medewerker" filter to prevent duplicate IDs
- keep single admin-only employee filter wrapper for proper population

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9974e990832ca6c675cbd52203a0