### PR TITLE
Add night shift validation and checkbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,11 @@
             <input id="eindtijd" type="time" required />
           </label>
 
+          <label class="small">
+            <input id="nachtshift" type="checkbox" />
+            Nachtelijke shift
+          </label>
+
           <label>Pauze (uur)
             <input id="pauze" type="number" step="0.25" min="0" value="0" />
           </label>

--- a/tests/calcHours.test.js
+++ b/tests/calcHours.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+// extract calcHours from app.js without running the whole file
+const appJs = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
+const match = appJs.match(/function calcHours[^]*?\n}\n/);
+if (!match) throw new Error('calcHours function not found');
+eval(match[0]); // defines calcHours
+
+// normale shift
+assert.strictEqual(calcHours('08:00', '16:00', '1', 0, 0), 7);
+
+// nachtelijke shift met checkbox
+assert.strictEqual(calcHours('22:00', '06:00', '0', 0, 0, true), 8);
+
+// foutmelding zonder nachtelijke shift
+let err;
+try {
+  calcHours('22:00', '06:00', '0', 0, 0, false);
+} catch (e) {
+  err = e;
+}
+assert.ok(err, 'Verwacht een foutmelding bij eindtijd < starttijd zonder nachtelijke shift');
+
+console.log('calcHours tests passed');
+


### PR DESCRIPTION
## Summary
- validate time entries so end before start is only allowed for explicit night shifts
- add "nachtelijke shift" checkbox to hours form and hook into submit handler
- cover normal and night shifts with basic calcHours tests

## Testing
- `node tests/calcHours.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ada0f248b0832c94e9ff1b701c477f